### PR TITLE
Temporarily remove ZapIn

### DIFF
--- a/src/views/Bond/BondPurchase.tsx
+++ b/src/views/Bond/BondPurchase.tsx
@@ -11,7 +11,7 @@ import { IAllBondData } from "../../hooks/Bonds";
 import useDebounce from "../../hooks/Debounce";
 import { messages } from "../../constants/messages";
 import { warning } from "../../store/slices/messages-slice";
-import Zapin from "./Zapin";
+//import Zapin from "./Zapin";
 
 interface IBondPurchaseProps {
   bond: IAllBondData;
@@ -27,7 +27,7 @@ function BondPurchase({ bond, slippage, recipientAddress }: IBondPurchaseProps) 
   const [useAvax, setUseAvax] = useState(false);
 
   const isBondLoading = useSelector<IReduxState, boolean>(state => state.bonding.loading ?? true);
-  const [zapinOpen, setZapinOpen] = useState(false);
+  //const [zapinOpen, setZapinOpen] = useState(false);
 
   const pendingTransactions = useSelector<IReduxState, IPendingTxn[]>(state => {
     return state.pendingTransactions;
@@ -111,15 +111,15 @@ function BondPurchase({ bond, slippage, recipientAddress }: IBondPurchaseProps) 
     dispatch(changeApproval({ address, bond, provider, networkID: chainID }));
   };
 
-  const handleZapinOpen = () => {
-    dispatch(calcBondDetails({ bond, value: "0", provider, networkID: chainID }));
-    setZapinOpen(true);
-  };
+  // const handleZapinOpen = () => {
+  //   dispatch(calcBondDetails({ bond, value: "0", provider, networkID: chainID }));
+  //   setZapinOpen(true);
+  // };
 
-  const handleZapinClose = () => {
-    dispatch(calcBondDetails({ bond, value: quantity, provider, networkID: chainID }));
-    setZapinOpen(false);
-  };
+  // const handleZapinClose = () => {
+  //   dispatch(calcBondDetails({ bond, value: quantity, provider, networkID: chainID }));
+  //   setZapinOpen(false);
+  // };
 
   const displayUnits = useAvax ? "AVAX" : bond.displayUnits;
 
@@ -243,7 +243,7 @@ function BondPurchase({ bond, slippage, recipientAddress }: IBondPurchaseProps) 
           )}
         </Box>
       </Slide>
-      <Zapin open={zapinOpen} handleClose={handleZapinClose} bond={bond} />
+      {/* //<Zapin open={zapinOpen} handleClose={handleZapinClose} bond={bond} /> */}
     </Box>
   );
 }


### PR DESCRIPTION
Just commented out the the zapin functionality for minting LP bonds, to stop making calls to the api, resulting in null responses