### PR TITLE
Fixed "Time until fully vested" display

### DIFF
--- a/src/store/slices/account-slice.ts
+++ b/src/store/slices/account-slice.ts
@@ -168,7 +168,7 @@ export const calculateUserBondDetails = createAsyncThunk(
 
     const bondDetails = await bondContract.bondInfo(address);
     interestDue = bondDetails.payout / Math.pow(10, 9);
-    bondMaturationBlock = Number(bondDetails.vesting) + Number(bondDetails.lastRug);
+    bondMaturationBlock = Number(bondDetails.vesting) + Number(bondDetails.lastTime);
     pendingPayout = await bondContract.pendingPayoutFor(address);
 
     let allowance,


### PR DESCRIPTION
### Summary
Minor fix, but I can assume that after converting all references of TIME to RUG when forking wonderland, you had accidentally replaced Time to Rug. Obviously on the contract the reference for lastRug doesn't exist.

How would you like PR's to be made? Perhaps making a template would be good.