### PR TITLE
Fixed "Time until fully vested" display

### DIFF
--- a/src/store/slices/account-slice.ts
+++ b/src/store/slices/account-slice.ts
@@ -168,7 +168,7 @@ export const calculateUserBondDetails = createAsyncThunk(
 
     const bondDetails = await bondContract.bondInfo(address);
     interestDue = bondDetails.payout / Math.pow(10, 9);
-    bondMaturationBlock = Number(bondDetails.vesting) + Number(bondDetails.lastRug);
+    bondMaturationBlock = Number(bondDetails.vesting) + Number(bondDetails.lastTime);
     pendingPayout = await bondContract.pendingPayoutFor(address);
 
     let allowance,

--- a/src/views/ChooseBond/choosebond.scss
+++ b/src/views/ChooseBond/choosebond.scss
@@ -24,7 +24,7 @@
 
     /* slightly transparent fallback for Firefox (not supporting backdrop-filter) */
     @supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
-      background: #3E3A71;
+      background: #3e3a71;
     }
 
     .choose-bond-view-card-header {
@@ -72,6 +72,7 @@
 
   .choose-bond-view-card-container {
     margin-top: 16px;
+    margin-bottom: 20%;
 
     .bond-data-card {
       margin: auto !important;
@@ -136,7 +137,7 @@
   }
 
   .bond-table-btn {
-    background: #2BA9AE;
+    background: #2ba9ae;
     border: 1px solid #767676;
     border-radius: 10px;
     padding: 6px 35.5px;


### PR DESCRIPTION
## Summary
Minor fix, but I can assume that after converting all references of TIME to RUG when forking wonderland, you had accidentally replaced Time to Rug when interacting with the bond details. Obviously for the bond contract the reference for lastRug doesn't exist.

## Suggestions
How would you like PR's to be made? Perhaps making a template would be good.

