### PR TITLE
Traderjoexyz and Rug Swap distinction

### DIFF
--- a/src/helpers/bond/index.ts
+++ b/src/helpers/bond/index.ts
@@ -96,7 +96,7 @@ export const wavax = new CustomBond({
 
 export const mimRug = new LPBond({
   name: "mim_time_lp",
-  displayName: "RUG-MIM LP",
+  displayName: "RUG-MIM JLP",
   bondToken: "MIM",
   bondIconSvg: MimRugIcon,
   bondContractABI: LpBondContract,
@@ -147,7 +147,7 @@ export const usdcRugRlp = new LPBond({
 
 export const avaxRug = new CustomLPBond({
   name: "avax_rug_lp",
-  displayName: "RUG-AVAX LP",
+  displayName: "RUG-AVAX JLP",
   bondToken: "AVAX",
   bondIconSvg: AvaxRugIcon,
   bondContractABI: LpBondContract,


### PR DESCRIPTION
## Summary
Switched out the links from the Trader Joes DEX to the Rug Swap DEX. In addition, since we have RLP to distinguish rug swap liquidity, it would only make sense that we should also distinguish the trader joes liquidity by making it JLP. Although, I'm not sure how the community would react, would they be knowledgable enough to understand LP vs JLP?

## TLDR
* Switched out trader joes link to rug swap
* Added a J to trader joe LP as we have two different liquidities contracts 