### PR TITLE
Removed forfeiting and staking when staking with a warm up balance

### DIFF
--- a/src/store/slices/stake-thunk.ts
+++ b/src/store/slices/stake-thunk.ts
@@ -103,15 +103,6 @@ export const changeStake = createAsyncThunk(
     try {
       const gasPrice = await getGasPrice(provider);
 
-      if (action === "stake" && warmUpBalance > 0) {
-        forfeitTx = await staking.forfeit({ gasPrice });
-        await forfeitTx.wait();
-      }
-      if (action === "claim") {
-        forfeitTx = await staking.claim(address, { gasPrice });
-        await forfeitTx.wait();
-      }
-
       if (action === "stake") {
         stakeTx = await stakingHelper.stake(ethers.utils.parseUnits(value, "gwei"), address, { gasPrice });
       } else {


### PR DESCRIPTION
## Summary
Removed the two if statements in stakingChange function. The forfeit because it's an unnecessary step and been has been causing much trouble for the community. Every day I see people complaining about this problem in the Discord. The second if statement is never called.

## Issue
![image](https://user-images.githubusercontent.com/43276017/145150839-0dfac552-d12e-4579-acfa-93d049e5225a.png)
