### PR TITLE
hide link to redeem page

### DIFF
--- a/src/components/Drawer/drawer-content/index.tsx
+++ b/src/components/Drawer/drawer-content/index.tsx
@@ -141,7 +141,7 @@ function NavContent() {
             </div>
           </Link> */}
 
-          <Link
+          {/* <Link
             component={NavLink}
             id="bond-nav"
             to="/redeem"
@@ -154,7 +154,7 @@ function NavContent() {
               <img alt="" src={BrowserIcon} />
               <p>Redeem RUG to USDC</p>
             </div>
-          </Link>
+          </Link> */}
         </div>
       </div>
       <div className="dapp-menu-doc-link">


### PR DESCRIPTION
Simple PR that will hide the redemption page from the front end. Will save confusion and avoid people reporting errors after redemption has ended. 
Commented out so if we want to bring it back in the future it will be very easy.